### PR TITLE
fix: show error on wrong command

### DIFF
--- a/packages/blueflag-test/src/index.js
+++ b/packages/blueflag-test/src/index.js
@@ -40,5 +40,9 @@ commander
         return Lint({singleFile, require, monorepo});
     });
 
+commander.on('command:*', () => {
+    log(`Invalid command: ${commander.args.join(' ')}\nSee --help for a list of available commands.`);
+    process.exit(1);
+});
 
 commander.parse(process.argv);


### PR DESCRIPTION
Upgrading from `blueflag-test@<0.22.0` to `blueflag-test@0.22.0` currently causes calls to `blueflag-test test` to complete without error, while running no tests, so it's easy to accidentally lose all test coverage if you miss the note to transfer over to `jest`. Now error exit codes are thrown when unsupported commands are used, so calling `blueflag-test test` will error out.